### PR TITLE
Added public docs folder with README and Oomph SetuP

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# IMPORTANT
+
+The content of this folder and it's subfolders is **public** under https://oasp.github.io/oasp4js

--- a/docs/oomph/projects/Oasp4js.setup
+++ b/docs/oomph/projects/Oasp4js.setup
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Project
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    name="oasp.4.js"
+    label="oasp4js">
+  <setupTask
+      xsi:type="setup:VariableTask"
+      name="github.project.name"
+      value="oasp4js"
+      storageURI="scope://Workspace"/>
+  <stream name="development"
+      label="Development"/>
+  <stream name="master"
+      label="Master"/>
+  <logicalProjectContainer
+      xsi:type="setup:ProjectCatalog"
+      href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']"/>
+  <description>OASP4JS Sample Application making use of the Application Template and ng-modules</description>
+</setup:Project>


### PR DESCRIPTION
Currently I'm working on an Oomph Project Catalog for devon. This provides a fast and easy setup for the ide and projects. 

To do so we decided to keep the corresponding project setups at the projects gh-pages. 

This PR adds the `docs` folder containing the oomph setups. To make it accessible you'll need to active this repos gh-pages based on the docs folder of the masterbranch. The setups itself reveal nothing of the repository except it's existence.